### PR TITLE
Enable mypy support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include py.typed

--- a/src/relic/core/__init__.py
+++ b/src/relic/core/__init__.py
@@ -1,4 +1,4 @@
 """
 Core files shared between other Relic-Tool packages.
 """
-__version__ = "1.0.2"
+__version__ = "1.0.3"


### PR DESCRIPTION
This fixes two issues preventing mypy from recognizing this package's inline types: 
1. `py.typed` was not in the package level directory.
2. `py.typed` was not included in the `MANIFEST.in`.

This PR fixes these two issues, and should allow mypy to type-check this package when installed.