### PR TITLE
Explicit None Checks in `_print_mismatch`

### DIFF
--- a/src/relic/core/__init__.py
+++ b/src/relic/core/__init__.py
@@ -1,4 +1,4 @@
 """
 Core files shared between other Relic-Tool packages.
 """
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/src/relic/core/errors.py
+++ b/src/relic/core/errors.py
@@ -6,13 +6,13 @@ from typing import Any, Optional, TypeVar, Generic
 
 def _print_mismatch(name: str, received: Optional[Any], expected: Optional[Any]) -> str:
     msg = f"Unexpected {name}"
-    if received or expected:
+    if received is not None or expected is not None:
         msg += ";"
-    if received:
+    if received is not None:
         msg += f" got `{str(received)}`"
-    if received and expected:
+    if received is not None and expected is not None:
         msg += ","
-    if expected:
+    if expected is not None:
         msg += f" expected `{str(expected)}`"
     return msg + "!"
 


### PR DESCRIPTION
Fixes Mak-Relic-Tool/Issue-Tracker#10

Explicitly compares against None to avoid printing less than useful error messages when falsy values are used.