### PR TITLE
Hotfix for `run_with` & `_load`

### DIFF
--- a/src/relic/core/__init__.py
+++ b/src/relic/core/__init__.py
@@ -1,4 +1,4 @@
 """
 Core files shared between other Relic-Tool packages.
 """
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from argparse import ArgumentParser, Namespace
-from typing import Optional, TYPE_CHECKING, Protocol, Any
+from typing import Optional, TYPE_CHECKING, Protocol, Any, Union
 
 import pkg_resources
 
@@ -18,7 +18,7 @@ class _SubParsersAction:  # pylint: disable= too-few-public-methods # typechecke
         help: Optional[str] = None,
         **kwargs: Any,
     ) -> ArgumentParser:
-        ...
+        raise NotImplementedError
 
 
 class CliEntrypoint(Protocol):  # pylint: disable= too-few-public-methods
@@ -36,12 +36,12 @@ class _CliPlugin:  # pylint: disable= too-few-public-methods
                 "Command defined in argparse, but it's function was not specified."
             )
         cmd = ns.cmd
-        result = cmd(ns)
+        result: Optional[int] = cmd(ns)
         if result is None:  # Assume success
             result = 0
         return result
 
-    def run_with(self, *args: Any) -> Optional[int]:
+    def run_with(self, *args: Any) -> Union[str, int, None]:
         try:
             ns = self.parser.parse_args(args)
             return self._run(ns)

--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -6,19 +6,19 @@ from typing import Optional, TYPE_CHECKING, Protocol, Any
 
 import pkg_resources
 
-if TYPE_CHECKING:
-    # Circumvent mypy/pylint shenanigans
-    class _SubParsersAction:  # pylint: disable= too-few-public-methods # typechecker only, ignore warnings
-        def add_parser(  # pylint: disable=redefined-builtin, unused-argument # typechecker only, ignore warnings
-            self,
-            name: str,
-            *,
-            prog: Optional[str] = None,
-            aliases: Optional[Any] = None,
-            help: Optional[str] = None,
-            **kwargs: Any,
-        ) -> ArgumentParser:
-            ...
+
+# Circumvent mypy/pylint shenanigans ~
+class _SubParsersAction:  # pylint: disable= too-few-public-methods # typechecker only, ignore warnings
+    def add_parser(  # pylint: disable=redefined-builtin, unused-argument # typechecker only, ignore warnings
+        self,
+        name: str,
+        *,
+        prog: Optional[str] = None,
+        aliases: Optional[Any] = None,
+        help: Optional[str] = None,
+        **kwargs: Any,
+    ) -> ArgumentParser:
+        ...
 
 
 class CliEntrypoint(Protocol):  # pylint: disable= too-few-public-methods
@@ -30,7 +30,7 @@ class _CliPlugin:  # pylint: disable= too-few-public-methods
     def __init__(self, parser: ArgumentParser):
         self.parser = parser
 
-    def _run(self, ns: Namespace) -> None:
+    def _run(self, ns: Namespace) -> int:
         if not hasattr(ns, "cmd"):
             raise NotImplementedError(
                 "Command defined in argparse, but it's function was not specified."
@@ -39,15 +39,19 @@ class _CliPlugin:  # pylint: disable= too-few-public-methods
         result = cmd(ns)
         if result is None:  # Assume success
             result = 0
-        sys.exit(result)
+        return result
 
-    def run_with(self, *args: Any) -> None:
-        ns = self.parser.parse_args(args)
-        self._run(ns)
+    def run_with(self, *args: Any) -> Optional[int]:
+        try:
+            ns = self.parser.parse_args(args)
+            return self._run(ns)
+        except SystemExit as sys_exit:
+            return sys_exit.code
 
     def run(self) -> None:
         ns = self.parser.parse_args()
-        self._run(ns)
+        exit_code = self._run(ns)
+        sys.exit(exit_code)
 
 
 class CliPluginGroup(_CliPlugin):  # pylint: disable= too-few-public-methods
@@ -64,6 +68,7 @@ class CliPluginGroup(_CliPlugin):  # pylint: disable= too-few-public-methods
         parser = self._create_parser(parent)
         super().__init__(parser)
         self.subparsers = self._create_subparser_group(parser)
+        self._load()
 
     def _create_parser(
         self, command_group: Optional[_SubParsersAction] = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,10 +14,8 @@ class CommandTests:
         cmd = subprocess.run(_args, capture_output=True, text=True)
         result = cmd.stdout
         status = cmd.returncode
-        print("= = =")
-        print(result)  # Visual Aid for Debugging
-        print("= = =")
-        assert result == output
+        print(f"'{result}'")  # Visual Aid for Debugging
+        assert output in result
         assert status == exit_code
 
     def test_run_with(self, args: Sequence[str], output: str, exit_code: int):
@@ -27,20 +25,11 @@ class CommandTests:
                 status = cli_root.run_with(*args)
             f.seek(0)
             result = f.read()
-            print("= = =")
-            print(result)  # Visual Aid for Debugging
-            print("= = =")
-            assert result == output
+            print(f"'{result}'")  # Visual Aid for Debugging
+            assert output in result
             assert status == exit_code
 
-_HELP = ["-h"], """usage: relic [-h] {} ...
-
-positional arguments:
-  {}
-
-optional arguments:
-  -h, --help  show this help message and exit
-""", 0
+_HELP = ["-h"], """usage: relic [-h] {} ...""", 0
 
 _TESTS = [_HELP]
 _TEST_IDS = [' '.join(_[0]) for _ in _TESTS]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,51 @@
 import subprocess
 
-
 # Local testing requires running `pip install -e "."`
-def test_cli():
-    cmd = subprocess.run(["relic", "-h"], capture_output=True, text=True)
-    data = cmd.stdout
-    assert "usage: relic [-h]" in data
-    exit_status = cmd.returncode
-    assert exit_status == 0
+from contextlib import redirect_stdout
+import io
+from typing import Sequence
+
+import pytest
+
+
+class CommandTests:
+    def test_run(self, args: Sequence[str], output: str, exit_code: int):
+        _args = ["relic", *args]
+        cmd = subprocess.run(_args, capture_output=True, text=True)
+        result = cmd.stdout
+        status = cmd.returncode
+        print("= = =")
+        print(result)  # Visual Aid for Debugging
+        print("= = =")
+        assert result == output
+        assert status == exit_code
+
+    def test_run_with(self, args: Sequence[str], output: str, exit_code: int):
+        from relic.core.cli import cli_root
+        with io.StringIO() as f:
+            with redirect_stdout(f):
+                status = cli_root.run_with(*args)
+            f.seek(0)
+            result = f.read()
+            print("= = =")
+            print(result)  # Visual Aid for Debugging
+            print("= = =")
+            assert result == output
+            assert status == exit_code
+
+_HELP = ["-h"], """usage: relic [-h] {} ...
+
+positional arguments:
+  {}
+
+optional arguments:
+  -h, --help  show this help message and exit
+""", 0
+
+_TESTS = [_HELP]
+_TEST_IDS = [' '.join(_[0]) for _ in _TESTS]
+
+
+@pytest.mark.parametrize(["args", "output", "exit_code"], _TESTS, ids=_TEST_IDS)
+class TestRelicCli(CommandTests):
+    ...


### PR DESCRIPTION
`run_with` no longer closes the calling process with sys.exit

`_load` is now called, to load plugins for the CLI

Updated tests to remove redundancy