### PR TITLE
Migrations for SGA 2.0.0

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ main, staging ]
+    branches: [main, staging]
     paths:
-      - 'src/relic/**'
-      - '.github/workflows/black.yml'
+    - src/relic/**
+    - .github/workflows/black.yml
   pull_request:
-    branches: [ main, staging ]
+    branches: [main, staging]
     paths:
-      - 'src/relic/**'
-      - '.github/workflows/black.yml'
+    - src/relic/**
+    - .github/workflows/black.yml
 
 jobs:
   black:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -4,21 +4,21 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ main, staging ]
+    branches: [main, staging]
     paths:
-      - 'src/relic/**'
-      - '.github/workflows/mypy.yml'
-      - 'mypy.ini'
+    - src/relic/**
+    - .github/workflows/mypy.yml
+    - pyproject.toml
   pull_request:
-    branches: [ main, staging ]
+    branches: [main, staging]
     paths:
-      - 'src/relic/**'
-      - '.github/workflows/mypy.yml'
-      - 'mypy.ini'
+    - src/relic/**
+    - .github/workflows/mypy.yml
+    - pyproject.toml
 
 jobs:
   mypy:
     uses: MAK-Relic-Tool/Workflows/.github/workflows/mypy.yml@main
     with:
-      package: "relic.core"
-      mypy-config: "pyproject.toml"
+      package: relic.core
+      mypy-config: pyproject.toml

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,22 +4,22 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ main, staging ]
+    branches: [main, staging]
     paths:
-      - 'src/**'
-      - '.github/workflows/pylint.yml'
-      - '.pylintrc'
-      - 'requirements.txt'
+    - src/**
+    - .github/workflows/pylint.yml
+    - .pylintrc
+    - requirements.txt
   pull_request:
-    branches: [ main, staging ]
+    branches: [main, staging]
     paths:
-      - 'src/**'
-      - '.github/workflows/pylint.yml'
-      - '.pylintrc'
-      - 'requirements.txt'
+    - src/**
+    - .github/workflows/pylint.yml
+    - .pylintrc
+    - requirements.txt
 
 jobs:
   pylint:
     uses: MAK-Relic-Tool/Workflows/.github/workflows/pylint.yml@main
     with:
-      path: "src"
+      path: src

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,26 +4,24 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ main, staging ]
+    branches: [main, staging]
     paths:
-      - 'src/**'
-      - 'tests/**'
-      - '.github/workflows/pytest.yml'
-      - 'setup.cfg'
-      - 'setup.py'
-      - 'MANIFEST.in'
-      - 'test-requirements.txt'
+    - src/**
+    - tests/**
+    - .github/workflows/pytest.yml
+    - pyproject.toml
+    - MANIFEST.in
+    - test-requirements.txt
 
   pull_request:
-    branches: [ main, staging ]
+    branches: [main, staging]
     paths:
-      - 'src/**'
-      - 'tests/**'
-      - '.github/workflows/pytest.yml'
-      - 'setup.cfg'
-      - 'setup.py'
-      - 'MANIFEST.in'
-      - 'test-requirements.txt'
+    - src/**
+    - tests/**
+    - .github/workflows/pytest.yml
+    - pyproject.toml
+    - MANIFEST.in
+    - test-requirements.txt
 
 jobs:
   pytest:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ __pycache__/
 src/**/*.egg-info/*
 dist/*
 
+# Ignore MyPy
+.mypy_cache/
+
 # Ignore docs
 ## Ignore compiled docs
 docs/build/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,33 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: check-case-conflict
-    -   id: check-docstring-first
-    -   id: check-json
-    -   id: pretty-format-json
-    -   id: check-merge-conflict
-    -   id: check-toml
-    -   id: check-yaml
-    -   id: mixed-line-ending
-    -   id: requirements-txt-fixer
--   repo: https://github.com/psf/black
-    rev: 24.1.1
-    hooks:
-    -   id: black
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
-    hooks:
-    -   id: mypy
-        args: [--explicit-package-bases, --namespace-packages]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: check-yaml
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: check-case-conflict
+  - id: check-docstring-first
+  - id: check-json
+  - id: pretty-format-json
+  - id: check-merge-conflict
+  - id: check-toml
+  - id: check-yaml
+  - id: mixed-line-ending
+  - id: requirements-txt-fixer
+- repo: https://github.com/psf/black
+  rev: 24.1.1
+  hooks:
+  - id: black
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.8.0
+  hooks:
+  - id: mypy
+    args: [--explicit-package-bases, --namespace-packages]
+
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.12.0
+  hooks:
+  - id: pretty-format-yaml
+    args: [--autofix]
+  - id: pretty-format-toml
+    args: [--autofix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
-  - id: check-case-conflict
+#  - id: check-case-conflict
   - id: check-docstring-first
   - id: check-json
   - id: pretty-format-json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Relic Tool - Core
 [![PyPI](https://img.shields.io/pypi/v/relic-tool-core)](https://pypi.org/project/relic-tool-core/)
-[![PyPI - Python Version](https://img.shields.io/pypi/v/relic-tool-core)](https://www.python.org/downloads/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/relic-tool-core)](https://www.python.org/downloads/)
 [![PyPI - License](https://img.shields.io/pypi/l/relic-tool-core)](https://github.com/MAK-Relic-Tool/Relic-Tool-Core/blob/main/LICENSE.txt)
 [![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/PyCQA/pylint)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,13 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Typing :: Typed",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
 dependencies = [
   "typing-extensions; python_version < '3.12'",
-  "importlib_metadata >= 6.5"
+  "importlib_metadata >= 6.5; python_version < '3.12'"
 ]
 description = "The core library used by other Relic-Tool packages."
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
-dependencies = ["typing-extensions; python_version < '3.12'", "importlib_metadata >= 3.6"]
+dependencies = [
+  "typing-extensions; python_version < '3.12'",
+  "importlib_metadata >= 6.5"
+]
 description = "The core library used by other Relic-Tool packages."
 dynamic = ["version"]
 name = "relic-tool-core"
@@ -60,6 +63,11 @@ module = ["tests.*"]
 ignore_errors = true
 ignore_missing_imports = true
 module = ["docs.*"]
+
+[[tool.mypy.overrides]]
+ignore_errors = true
+ignore_missing_imports = true
+module = ["importlib_metadata.*"]
 
 [tool.semantic_release]
 assets = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,11 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
-dependencies = ["typing-extensions; python_version < '3.12'"]
+dependencies = ["typing-extensions; python_version < '3.12'", "importlib_metadata >= 3.6"]
 description = "The core library used by other Relic-Tool packages."
 dynamic = ["version"]
 name = "relic-tool-core"
 requires-python = ">=3.9"
-dependencies = [
-  "importlib_metadata >= 3.6"
-]
 
 [project.readme]
 content-type = "text/markdown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
 dependencies = ["typing-extensions; python_version < '3.12'"]
@@ -16,6 +17,9 @@ description = "The core library used by other Relic-Tool packages."
 dynamic = ["version"]
 name = "relic-tool-core"
 requires-python = ">=3.9"
+dependencies = [
+  "importlib_metadata >= 3.6"
+]
 
 [project.readme]
 content-type = "text/markdown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,75 +1,64 @@
 [build-system]
-requires = ["setuptools>=61.2"]
 build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61.2"]
 
 [project]
-name = "relic-tool-core"
 authors = [{name = "Marcus Kertesz"}]
-description = "The core library used by other Relic-Tool packages."
 classifiers = [
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
-requires-python = ">=3.9"
 dependencies = ["typing-extensions; python_version < '3.12'"]
+description = "The core library used by other Relic-Tool packages."
 dynamic = ["version"]
+name = "relic-tool-core"
+requires-python = ">=3.9"
 
 [project.readme]
-file = "README.md"
 content-type = "text/markdown"
-
-[project.urls]
-Homepage = "https://github.com/MAK-Relic-Tool/Relic-Tool-Core"
-"Bug Tracker" = "https://github.com/MAK-Relic-Tool/Issues-Tracker/issues"
+file = "README.md"
 
 [project.scripts]
 relic = "relic.core.cli:CLI.run"
 
-[tool.setuptools]
-include-package-data = true
-package-dir = {"" = "src"}
-
-[tool.setuptools.packages.find]
-where = ["src"]
-namespaces = true
-
-[tool.setuptools.dynamic]
-version = {attr = "relic.core.__version__"}
+[project.urls]
+"Bug Tracker" = "https://github.com/MAK-Relic-Tool/Issues-Tracker/issues"
+Homepage = "https://github.com/MAK-Relic-Tool/Relic-Tool-Core"
 
 [tool.mypy]
-mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
-warn_unused_configs = true
+check_untyped_defs = true
 disallow_any_generics = true
+disallow_incomplete_defs = true
 disallow_subclassing_any = true
 disallow_untyped_calls = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
 disallow_untyped_decorators = true
+disallow_untyped_defs = true
+extra_checks = true
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_return_any = true
 no_implicit_reexport = true
 strict_equality = true
-extra_checks = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
+ignore_missing_imports = true
 module = ["serialization_tools.*"]
-ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+ignore_errors = true
+ignore_missing_imports = true
 module = ["tests.*"]
-ignore_missing_imports = true
-ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["docs.*"]
-ignore_missing_imports = true
 ignore_errors = true
+ignore_missing_imports = true
+module = ["docs.*"]
 
 [tool.semantic_release]
 assets = []
@@ -81,47 +70,58 @@ tag_format = "v{version}"
 version_variables = ["src/relic/core/__init__.py:__version__"]
 
 [tool.semantic_release.branches.main]
-match = "(main|master)"
-prerelease_token = "rc"
+match = "(main|master|staging)"
 prerelease = false
+prerelease_token = "rc"
 
 [tool.semantic_release.changelog]
-template_dir = "templates"
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
+template_dir = "templates"
 
 [tool.semantic_release.changelog.environment]
-block_start_string = "{%"
+autoescape = true
 block_end_string = "%}"
-variable_start_string = "{{"
-variable_end_string = "}}"
-comment_start_string = "{#"
+block_start_string = "{%"
 comment_end_string = "#}"
-trim_blocks = false
+comment_start_string = "{#"
+extensions = []
+keep_trailing_newline = false
 lstrip_blocks = false
 newline_sequence = "\n"
-keep_trailing_newline = false
-extensions = []
-autoescape = true
+trim_blocks = false
+variable_end_string = "}}"
+variable_start_string = "{{"
 
 [tool.semantic_release.commit_author]
-env = "GIT_COMMIT_AUTHOR"
 default = "semantic-release <semantic-release>"
+env = "GIT_COMMIT_AUTHOR"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "style", "refactor", "test"]
+default_bump_level = 0
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
-default_bump_level = 0
-
-[tool.semantic_release.remote]
-name = "origin"
-type = "github"
-ignore_token_for_push = false
-
-[tool.semantic_release.remote.token]
-env = "GH_TOKEN"
 
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
 upload_to_vcs_release = true
+
+[tool.semantic_release.remote]
+ignore_token_for_push = false
+name = "origin"
+type = "github"
+
+[tool.semantic_release.remote.token]
+env = "GH_TOKEN"
+
+[tool.setuptools]
+include-package-data = true
+package-dir = {"" = "src"}
+
+[tool.setuptools.dynamic]
+version = {attr = "relic.core.__version__"}
+
+[tool.setuptools.packages.find]
+namespaces = true
+where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-importlib-metadata>=6.5
+importlib-metadata>=6.5; python_version < '3.12'
 typing-extensions; python_version < '3.12'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+importlib-metadata>=6.5
 typing-extensions; python_version < '3.12'

--- a/src/relic/core/__init__.py
+++ b/src/relic/core/__init__.py
@@ -2,7 +2,7 @@
 Core files shared between other Relic-Tool packages.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 from relic.core.cli import CLI
 

--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -1,14 +1,13 @@
 """
 Core files for implementing a Command Line Interface using Entrypoints
-
-
 """
 
 from __future__ import annotations
 
 import sys
 from argparse import ArgumentParser, Namespace, ArgumentError, Action
-from importlib.metadata import entry_points, EntryPoints
+from gettext import gettext
+from importlib_metadata import entry_points
 from os.path import basename
 from typing import (
     Optional,
@@ -23,18 +22,21 @@ from typing import (
 from relic.core.errors import UnboundCommandError
 
 
-class RelicArgParserError(Exception): ...
+class RelicArgParserError(Exception):
+    """An error occurred while parsing Command Line arguments"""
 
 
 def _print_error(parser: ArgumentParser, message: str) -> None:
-    from gettext import gettext as _
-
     parser.print_usage(sys.stderr)
     args = {"prog": parser.prog, "message": message}
-    parser.exit(2, _("%(prog)s: error: %(message)s\n") % args)
+    parser.exit(2, gettext("%(prog)s: error: %(message)s\n") % args)
 
 
 class RelicArgParser(ArgumentParser):
+    """
+    Custom ArgParser with special error handling
+    """
+
     def _get_action_from_name(self, name: str | None) -> Action | None:
         """Given a name, get the Action instance registered with this parser.
         If only it were made available in the ArgumentError object. It is
@@ -46,15 +48,15 @@ class RelicArgParser(ArgumentParser):
         for action in container:
             if "/".join(action.option_strings) == name:
                 return action
-            elif action.metavar == name:
+            if action.metavar == name:
                 return action
-            elif action.dest == name:
+            if action.dest == name:
                 return action
 
         return None  # not found
 
     def error(self, message: str) -> NoReturn:
-        exc_type, exc, tb = sys.exc_info()
+        _, exc, _ = sys.exc_info()
         if exc is not None:
             if isinstance(exc, ArgumentError) and exc.argument_name is None:
                 action = self._get_action_from_name(exc.argument_name)
@@ -237,12 +239,14 @@ class CliPluginGroup(_CliPlugin):  # pylint: disable= too-few-public-methods
         Load all entrypoints using the group specified by the class-variable GROUP
         """
 
-        all_entry_points: EntryPoints = entry_points()
-        for ep in all_entry_points.select(group=self.GROUP):
+        for ep in entry_points().select(group=self.GROUP):
             ep_func: CliEntrypoint = ep.load()
             ep_func(parent=self.subparsers)
 
-    def command(self, ns: Namespace) -> Optional[int]:
+    def command(self, ns: Namespace) -> Optional[int]:  # pylint: disable=W0613
+        """
+        Adapter which extracts parsed CLI arguments from the namespace and runs the appropriate CLI command
+        """
         self.parser.print_help(sys.stderr)
         return 1
 

--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import sys
 from argparse import ArgumentParser, Namespace, ArgumentError, Action
 from gettext import gettext
-from importlib_metadata import entry_points
 from os.path import basename
 from typing import (
     Optional,
@@ -20,6 +19,7 @@ from typing import (
 )
 
 from relic.core.errors import UnboundCommandError
+from relic.core.typeshed import entry_points
 
 
 class RelicArgParserError(Exception):

--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import sys
 from argparse import ArgumentParser, Namespace, ArgumentError, Action
-from importlib.metadata import entry_points, EntryPoint
+from importlib.metadata import entry_points, EntryPoints
 from os.path import basename
 from typing import (
     Optional,
@@ -16,13 +16,11 @@ from typing import (
     Protocol,
     Any,
     Union,
-    List,
-    Dict,
     Sequence,
     NoReturn,
 )
 
-from relic.core.errors import UnboundCommandError, RelicToolError
+from relic.core.errors import UnboundCommandError
 
 
 class RelicArgParserError(Exception): ...
@@ -239,8 +237,8 @@ class CliPluginGroup(_CliPlugin):  # pylint: disable= too-few-public-methods
         Load all entrypoints using the group specified by the class-variable GROUP
         """
 
-        all_entry_points: EntryPoints = entry_points()  # type: ignore[assignment, unused-ignore]
-        for ep in all_entry_points.select(group = self.GROUP):
+        all_entry_points: EntryPoints = entry_points()
+        for ep in all_entry_points.select(group=self.GROUP):
             ep_func: CliEntrypoint = ep.load()
             ep_func(parent=self.subparsers)
 

--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -239,8 +239,8 @@ class CliPluginGroup(_CliPlugin):  # pylint: disable= too-few-public-methods
         Load all entrypoints using the group specified by the class-variable GROUP
         """
 
-        all_entry_points: Dict[str, List[EntryPoint]] = entry_points()  # type: ignore[assignment, unused-ignore]
-        for ep in all_entry_points.get(self.GROUP, []):
+        all_entry_points: EntryPoints = entry_points()  # type: ignore[assignment, unused-ignore]
+        for ep in all_entry_points.select(group = self.GROUP):
             ep_func: CliEntrypoint = ep.load()
             ep_func(parent=self.subparsers)
 

--- a/src/relic/core/entrytools.py
+++ b/src/relic/core/entrytools.py
@@ -30,8 +30,6 @@ _TValue_contra = TypeVar(  # pylint: disable=invalid-name
 _TValue_co = TypeVar("_TValue_co", covariant=True)  # pylint: disable=invalid-name
 
 
-
-
 class KeyFunc(Protocol[_TKey_contra]):  # pylint: disable=too-few-public-methods
     """
     A function which converts an object to a string representation for an entrypoint
@@ -147,7 +145,9 @@ class EntrypointRegistry(MutableMapping[Union[str, _TKey], _TValue]):
         Load all entrypoints from the group specified in __init__
         """
         all_entrypoints: EntryPoints = entry_points()
-        group_entrypoints: List[EntryPoint] = all_entrypoints.select(group=self._ep_group)
+        group_entrypoints: List[EntryPoint] = all_entrypoints.select(
+            group=self._ep_group
+        )
         for ep in group_entrypoints:
             ep_name: str = ep.name
             ep_func: _TValue = ep.load()

--- a/src/relic/core/entrytools.py
+++ b/src/relic/core/entrytools.py
@@ -4,7 +4,7 @@ Tools for handling entrypoints via class-based registries
 
 from __future__ import annotations
 
-from importlib.metadata import entry_points, EntryPoint
+from importlib.metadata import entry_points, EntryPoint, EntryPoints
 from typing import (
     TypeVar,
     Protocol,
@@ -28,6 +28,8 @@ _TValue_contra = TypeVar(  # pylint: disable=invalid-name
     "_TValue_contra", contravariant=True
 )
 _TValue_co = TypeVar("_TValue_co", covariant=True)  # pylint: disable=invalid-name
+
+
 
 
 class KeyFunc(Protocol[_TKey_contra]):  # pylint: disable=too-few-public-methods
@@ -144,8 +146,8 @@ class EntrypointRegistry(MutableMapping[Union[str, _TKey], _TValue]):
         """
         Load all entrypoints from the group specified in __init__
         """
-        all_entrypoints: Dict[str, List[EntryPoint]] = entry_points()  # type: ignore[assignment, unused-ignore]
-        group_entrypoints: List[EntryPoint] = all_entrypoints.get(self._ep_group, [])
+        all_entrypoints: EntryPoints = entry_points()
+        group_entrypoints: List[EntryPoint] = all_entrypoints.select(group=self._ep_group)
         for ep in group_entrypoints:
             ep_name: str = ep.name
             ep_func: _TValue = ep.load()

--- a/src/relic/core/entrytools.py
+++ b/src/relic/core/entrytools.py
@@ -4,7 +4,7 @@ Tools for handling entrypoints via class-based registries
 
 from __future__ import annotations
 
-from importlib.metadata import entry_points, EntryPoint, EntryPoints
+from importlib_metadata import entry_points
 from typing import (
     TypeVar,
     Protocol,
@@ -13,7 +13,6 @@ from typing import (
     Optional,
     Iterable,
     MutableMapping,
-    List,
 )
 
 from relic.core.errors import RelicToolError
@@ -144,11 +143,7 @@ class EntrypointRegistry(MutableMapping[Union[str, _TKey], _TValue]):
         """
         Load all entrypoints from the group specified in __init__
         """
-        all_entrypoints: EntryPoints = entry_points()
-        group_entrypoints: List[EntryPoint] = all_entrypoints.select(
-            group=self._ep_group
-        )
-        for ep in group_entrypoints:
+        for ep in entry_points().select(group=self._ep_group):
             ep_name: str = ep.name
             ep_func: _TValue = ep.load()
             self._raw_register(ep_name, ep_func)

--- a/src/relic/core/entrytools.py
+++ b/src/relic/core/entrytools.py
@@ -4,7 +4,6 @@ Tools for handling entrypoints via class-based registries
 
 from __future__ import annotations
 
-from importlib_metadata import entry_points
 from typing import (
     TypeVar,
     Protocol,
@@ -16,6 +15,7 @@ from typing import (
 )
 
 from relic.core.errors import RelicToolError
+from relic.core.typeshed import entry_points
 
 _TKey = TypeVar("_TKey")  # pylint: disable=invalid-name
 _TKey_contra = TypeVar(  # pylint: disable=invalid-name

--- a/src/relic/core/errors.py
+++ b/src/relic/core/errors.py
@@ -2,6 +2,8 @@
 Errors shared across all Relic Tools.
 """
 
+from __future__ import annotations
+
 from typing import Any, Optional, TypeVar, Generic
 
 
@@ -98,10 +100,36 @@ class MagicMismatchError(MismatchError[bytes]):
     """
 
 
+class RelicSerializationError(RelicToolError):
+    """
+    An error was raised while serializing an object.
+    """
+
+
+class RelicSerializationSizeError(RelicSerializationError):
+    """
+    While serializing an object, the size of the binary buffer did not match the expected read or write size
+    """
+
+    def __init__(
+        self,
+        msg: str = "Size Mismatch",
+        size: Optional[int] = None,
+        expected: Optional[int] = None,
+        payload: Optional[str] = None,
+    ):
+        self.size = (size,)
+        self.expected = expected
+        self.payload = payload
+        super().__init__(msg)
+
+
 __all__ = [
     "RelicToolError",
     "MismatchError",
     "MagicMismatchError",
     "CliError",
     "UnboundCommandError",
+    "RelicSerializationError",
+    "RelicSerializationSizeError",
 ]

--- a/src/relic/core/lazyio.py
+++ b/src/relic/core/lazyio.py
@@ -26,9 +26,9 @@ from typing import (
     List,
     TypeVar,
     Generic,
+    Sized,
 )
-
-from relic.core.errors import RelicToolError, MismatchError
+from relic.core.errors import RelicToolError, MismatchError, RelicSerializationSizeError
 from relic.core.typeshed import Buffer
 
 ByteOrder = Literal["big", "little"]
@@ -250,7 +250,7 @@ class BinaryWindow(BinaryWrapper):
     Maintains an internal pointer to the current position of the window, ignoring the parent stream's current position
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=R0917
         self,
         parent: Union[BinaryIO, BinaryProxy],
         start: int,
@@ -321,9 +321,9 @@ class BinaryWindow(BinaryWrapper):
     def write(self, __s: Union[bytes, Buffer]) -> int:
         remaining = self._remaining
 
-        if len(__s) > remaining:  # type: ignore[arg-type]
+        if isinstance(__s, Sized) and len(__s) > remaining:
             raise RelicToolError(
-                f"Cannot write {len(__s)} bytes, only {remaining} bytes remaining!"  # type: ignore[arg-type]
+                f"Cannot write {len(__s)} bytes, only {remaining} bytes remaining!"
             )
 
         with self.__rw_ctx():
@@ -389,7 +389,8 @@ class _CStringOps:
                 if pad_count != int(pad_count):
                     raise RelicToolError(
                         f"Trying to pad '{buffer!r}' ({len(buffer)}) to '{size}' bytes,"
-                        f" but padding '{pad_buffer!r}' ({len(pad_buffer)}) is not a multiple of '{size - len(buffer)}' !"
+                        f" but padding '{pad_buffer!r}' ({len(pad_buffer)})"
+                        f" is not a multiple of '{size - len(buffer)}' !"
                     )
                 buffer = b"".join([buffer, pad_buffer * int(pad_count)])
             elif len(buffer) != size:
@@ -516,15 +517,19 @@ class _SizedIntOps(_IntOps):
         return self._serializer.write_bytes(buffer, offset, size)
 
     def read_le(self, offset: int, size: Optional[int] = None) -> int:
+        """Read little endian integer"""
         return self.read(offset=offset, size=size, byteorder="little")
 
     def write_le(self, value: int, offset: int, size: Optional[int] = None) -> int:
+        """Write little endian integer"""
         return self.write(value=value, offset=offset, size=size, byteorder="little")
 
     def read_be(self, offset: int, size: Optional[int] = None) -> int:
+        """Read big endian integer"""
         return self.read(offset=offset, size=size, byteorder="big")
 
     def write_be(self, value: int, offset: int, size: Optional[int] = None) -> int:
+        """Write big endian integer"""
         return self.write(value=value, offset=offset, size=size, byteorder="big")
 
     def unpack(
@@ -822,7 +827,7 @@ def read_chunks(
                 yield buffer
 
 
-def chunk_copy(
+def chunk_copy(  # pylint: disable=R0917
     src: Union[BinaryIO, bytes, bytearray],
     dest: Union[BinaryIO, bytearray],
     src_start: Optional[int] = None,
@@ -890,29 +895,12 @@ class BinaryConverter(Protocol[_T]):
 
 class ByteConverter(BinaryConverter[bytes]):
     @classmethod
-    def bytes2value(cls, b: bytes) -> bytes:
+    def bytes2value(cls, b: bytes) -> bytes:  # pylint: disable=W0221
         return b
 
     @classmethod
-    def value2bytes(cls, v: bytes) -> bytes:
+    def value2bytes(cls, v: bytes) -> bytes:  # pylint: disable=W0221
         return v
-
-
-class RelicSerializationError(RelicToolError): ...
-
-
-class RelicSerializationSizeError(RelicSerializationError):
-    def __init__(
-        self,
-        msg: str = "Size Mismatch",
-        size: Optional[int] = None,
-        expected: Optional[int] = None,
-        payload: Optional[str] = None,
-    ):
-        self.size = (size,)
-        self.expected = expected
-        self.payload = payload
-        super().__init__(msg)
 
 
 class IntConverter(BinaryConverter[int]):
@@ -982,6 +970,11 @@ class CStringConverter(BinaryConverter[str]):
 
 
 class BinaryProperty(Generic[_T]):
+    """
+    Helper class to convert binary data to typed data as a lazy property
+    Expect a BinaryIO '_serializer' object on the parent object
+    """
+
     def __init__(self, start: int, size: int, converter: BinaryConverter[_T]):
         self._start = start
         self._size = size
@@ -1000,18 +993,26 @@ class BinaryProperty(Generic[_T]):
 
     @contextmanager
     def _window(self, stream: BinaryIO) -> Generator[BinaryIO, None, None]:
+        """Open a window into the stream from the expected start and end of this data's location"""
         yield BinaryWindow(stream, self._start, self._size)
 
     def _read(self, stream: BinaryIO) -> bytes:
+        """Read a byte buffer from the given stream"""
         with self._window(stream) as window:
             return window.read()
 
     def _write(self, stream: BinaryIO, value: bytes) -> None:
+        """Write the byte buffer to the given stream"""
         with self._window(stream) as window:
             window.write(value)
 
 
 class ConstProperty(Generic[_T]):
+    """
+    A property for a contsant value
+    Raises an error if a new constant is set
+    """
+
     def __init__(self, value: _T, err: Exception):
         self._value = value
         self._err = err

--- a/src/relic/core/lazyio.py
+++ b/src/relic/core/lazyio.py
@@ -107,8 +107,14 @@ class BinaryWrapper(BinaryIO):
         :returns: The name of the binary wrapper.
         :rtype: str
         """
-        return self._name or (
-            self._handle.name if hasattr(self._handle, "name") else str(self._handle)
+        return (
+            self._name
+            if self._name is not None
+            else (
+                self._handle.name
+                if hasattr(self._handle, "name")
+                else str(self._handle)
+            )
         )
 
     def close(self) -> None:
@@ -130,7 +136,6 @@ class BinaryWrapper(BinaryIO):
 
     def fileno(self) -> int:
         "`fileno() on python.org <https://docs.python.org/library/typing.html#typing.IO.fileno>`_"
-
         return self._handle.fileno()
 
     def flush(self) -> None:

--- a/src/relic/core/typeshed.py
+++ b/src/relic/core/typeshed.py
@@ -16,4 +16,9 @@ try:  # 3.12+
 except ImportError:
     from typing_extensions import Buffer
 
-__all__ = ["TypeAlias", "Buffer"]
+try:  # 3.12- (Use backport if found, otherwise assume stdlib meets minimum requirements)
+    from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
+
+__all__ = ["TypeAlias", "Buffer", "entry_points"]

--- a/src/relic/core/typeshed.py
+++ b/src/relic/core/typeshed.py
@@ -2,17 +2,18 @@
 Provides a version safe interface for retrieving attributes from the typing / typing_extensions modules.
 """
 
-import sys
+# mypy: ignore-errors
+# pylint: skip-file
 
-if sys.version_info[0:2] >= (3, 10):
-    from typing import TypeAlias  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import TypeAlias  # pylint: disable=no-name-in-module
 
-if sys.version_info[0:2] >= (3, 12):
-    from collections.abc import Buffer  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import Buffer  # pylint: disable=no-name-in-module
+try:  # 3.10+
+    from typing import TypeAlias
+except ImportError:
+    from typing_extensions import TypeAlias
 
+try:  # 3.12+
+    from collections.abc import Buffer
+except ImportError:
+    from typing_extensions import Buffer
 
 __all__ = ["TypeAlias", "Buffer"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import subprocess
+from argparse import ArgumentError
 
 # Local testing requires running `pip install -e "."`
 from contextlib import redirect_stdout, redirect_stderr
@@ -36,17 +37,67 @@ class CommandTests:
             assert status == exit_code
 
 
+class CommandExceptionTests:
+
+    def test_run(self, args: Sequence[str], exception: Exception, exit_code: int):
+        cmd = subprocess.run(args, capture_output=True, text=True)
+        result = cmd.stdout if False else cmd.stderr
+        status = cmd.returncode
+        print(f"'{result}'")  # Visual Aid for Debugging
+        assert status == exit_code
+        assert str(exception) in result
+
+    def test_run_with(self, args: Sequence[str], exception: Exception, exit_code: int):
+        from relic.core.cli import CLI
+
+        try:
+            status = CLI.run_with(*args)
+            assert status == exit_code
+        except Exception as caught:
+            if isinstance(exception, ArgumentError) and isinstance(
+                caught, ArgumentError
+            ):
+                assert caught.argument_name == exception.argument_name
+                assert caught.message == exception.message
+            else:
+                assert caught == exception
+
+
+def _ArgumentError(name: str, message: str):
+    _ = ArgumentError(None, message)
+    _.argument_name = name
+    return _
+
+
 _HELP = ["relic", "-h"], """usage: relic [-h] {} ...""", 0, True
 _NO_SUB_CMD = ["relic"], """usage: relic [-h] {} ...""", 1, False
 _T = """relic: error: argument command: invalid choice: '{name}' (choose from )"""
-_BAD_SUB_CMD = ["relic", "Paul_Chambers"], _T.format(name="Paul_Chambers"), 2, False
+_BAD_SUB_CMD = (
+    ["relic", "Paul_Chambers"],
+    _ArgumentError("command", "invalid choice: 'Paul_Chambers' (choose from )"),
+    2,
+)
 
 
-_TESTS = [_HELP, _NO_SUB_CMD, _BAD_SUB_CMD]
-_TEST_IDS = [" ".join(str(__) for __ in _[0]) for _ in _TESTS]
+_PRINT_TESTS = [_HELP, _NO_SUB_CMD]
+_PRINT_TEST_IDS = [" ".join(str(__) for __ in _[0]) for _ in _PRINT_TESTS]
+_EX_TESTS = [_BAD_SUB_CMD]
+_EX_TEST_IDS = [" ".join(str(__) for __ in _[0]) for _ in _EX_TESTS]
 
 
 @pytest.mark.parametrize(
-    ["args", "output", "exit_code", "stdout"], _TESTS, ids=_TEST_IDS
+    ["args", "output", "exit_code", "stdout"], _PRINT_TESTS, ids=_PRINT_TEST_IDS
 )
 class TestRelicCli(CommandTests): ...
+
+
+@pytest.mark.parametrize(
+    [
+        "args",
+        "exception",
+        "exit_code",
+    ],
+    _EX_TESTS,
+    ids=_EX_TEST_IDS,
+)
+class TestRelicCliExceptions(CommandExceptionTests): ...


### PR DESCRIPTION
- CLI will try to throw a RelicArgParseError when an error with command line arguments occurs
- Uses the EntryPoints interface defined in Py3.12; importlib_metadata backport is installed for python versions <3.11
  - relic.core.typeshed now handles exporting the entry_points function to avoid confusion between the backport and standard library
- LazyIO includes a few 'properties' to simplify lazy dataclasses
