### PR TITLE
Add logging format objects

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -283,7 +283,7 @@ single-line-if-stmt=no
 
 # The type of string formatting that logging methods do. `old` means using %
 # formatting, `new` is for `{}` formatting.
-logging-format-style=new
+logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.

--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -408,8 +408,8 @@ class CliPluginGroup(_CliPlugin):  # pylint: disable= too-few-public-methods
             ep_func(parent=self.subparsers)
 
     def command(
-        self, ns: Namespace, *, logger: logging.Logger
-    ) -> Optional[int]:  # pylint: disable=W0613
+        self, ns: Namespace, *, logger: logging.Logger  # pylint: disable=W0613
+    ) -> Optional[int]:
         """
         Adapter which extracts parsed CLI arguments from the namespace and runs the appropriate CLI command
         """

--- a/src/relic/core/lazyio.py
+++ b/src/relic/core/lazyio.py
@@ -26,8 +26,8 @@ from typing import (
     List,
     TypeVar,
     Generic,
-    Sized,
 )
+from collections.abc import Sized
 from relic.core.errors import RelicToolError, MismatchError, RelicSerializationSizeError
 from relic.core.typeshed import Buffer
 

--- a/src/relic/core/logmsg.py
+++ b/src/relic/core/logmsg.py
@@ -1,0 +1,87 @@
+"""
+Objects to allow logging to handle different string formatters
+Including:
+- Old Style  (E.G. '%s', '%(message)s')
+- Brace (E.G. '{0}', '{message}')
+- Dollar (N.E.G.)
+"""
+
+import logging
+from typing import Any
+from string import Template
+
+logger = logging.getLogger(__name__)
+
+
+class FormattedMessage:  # pylint: disable=R0903
+    """
+    Base Class for lazily formatting messages for logging
+    All formatting logic should be placed in __str__ to allow the logger to discard any unprinted string conversions
+    """
+
+    def __init__(self, fmt: str, *args: Any, **kwargs: Any):
+        self.fmt = fmt
+        self.args = args
+        self.kwargs = kwargs
+        self._init_warn()
+
+    def _init_warn(self) -> None:
+        pass
+
+    def __str__(self) -> str:
+        raise NotImplementedError
+
+
+class BraceMessage(FormattedMessage):  # pylint: disable=R0903
+    """
+    Object to allow logging to handle the Brace string formatter '{0}' & '{message}'
+    """
+
+    def __str__(self) -> str:
+        return self.fmt.format(*self.args, **self.kwargs)
+
+
+class DollarMessage(FormattedMessage):  # pylint: disable=R0903
+    """
+    Object to allow logging to handle the Dollar string formatter
+    """
+
+    def _init_warn(self) -> None:
+        if len(self.args) > 0:
+            logger.warning(
+                "%s was passed %d positional arguments, which will be ignored",
+                self.__class__,
+                len(self.args),
+            )
+
+    def __str__(self) -> str:
+        return Template(self.fmt).substitute(**self.kwargs)
+
+
+class PercentMessage(FormattedMessage):  # pylint: disable=R0903
+    """
+    Object to allow logging to handle the Percent formatter '%s' & '%(message)s'
+    logging supports this by default; this class is provided for convenience
+    """
+
+    def _init_warn(self) -> None:
+        if len(self.kwargs) > 0 and len(self.args) > 0:
+            logger.warning(
+                "%s was passed %d keyword arguments and %d positional arguments,"
+                " only one can be specified. Defaulting to keyword arguments",
+                self.__class__,
+                len(self.args),
+                len(self.kwargs),
+            )
+
+    def __str__(self) -> str:
+        fmt_args = self.kwargs if len(self.kwargs) > 0 else self.args
+        return self.fmt % fmt_args
+
+
+__all__ = [
+    "FormattedMessage",
+    "BraceMessage",
+    "DollarMessage",
+    "PercentMessage",
+]


### PR DESCRIPTION
Same signature should allow me to hotswap them at will

For best results, always use keyword argument, as DollarMessage does not support positional arguments, and ignores them

Closes MAK-Relic-Tool/Issue-Tracker/issues/57


As an aside, somehow the core lib doesn't have any logging calls; outside of one call which prints the usage of the topmost group command. (which is a bug that i thought i had an issue for)