### PR TITLE
Error messages does not print properly

### DIFF
--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -28,7 +28,11 @@ from typing import (
     List,
 )
 
-from relic.core.errors import UnboundCommandError, RelicArgParserError, RelicInputFileError
+from relic.core.errors import (
+    UnboundCommandError,
+    RelicArgParserError,
+    RelicInputFileError,
+)
 from relic.core.typeshed import entry_points
 
 

--- a/src/relic/core/cli.py
+++ b/src/relic/core/cli.py
@@ -28,7 +28,7 @@ from typing import (
     List,
 )
 
-from relic.core.errors import UnboundCommandError, RelicArgParserError
+from relic.core.errors import UnboundCommandError, RelicArgParserError, RelicInputFileError
 from relic.core.typeshed import entry_points
 
 
@@ -410,8 +410,12 @@ class _CliPlugin:  # pylint: disable= too-few-public-methods
         if not hasattr(ns, "function"):
             raise UnboundCommandError(cmd)
         func = ns.function
+        result: Optional[int] = None
         with setup_cli_logging(ns, logger, log_setup_options) as cli_logger:
-            result: Optional[int] = func(ns, logger=cli_logger)
+            try:
+                result = func(ns, logger=cli_logger)
+            except RelicInputFileError as error:
+                cli_logger.info(f"relic: {error}")
         if result is None:  # Assume success
             result = 0
         return result

--- a/src/relic/core/errors.py
+++ b/src/relic/core/errors.py
@@ -52,6 +52,14 @@ class RelicToolError(Exception):
     """
 
 
+class RelicInputFileError(RelicToolError):
+    """
+    An non critical error was raised during input file parsing. 
+
+    All non critical error raised during input file handling in this library and it's plugins should inherit from this class. Only error message without trace is logged. 
+    """
+
+
 class CliError(RelicToolError):
     """
     An error was raised by the command line interface.
@@ -75,7 +83,7 @@ class UnboundCommandError(CliError):
         return f"The '{self._name}' command was defined, but not bound to a function."
 
 
-class MismatchError(Generic[_T], RelicToolError):
+class MismatchError(Generic[_T], RelicInputFileError):
     """
     An error where a received value did not match the expected value.
     """
@@ -100,7 +108,7 @@ class MagicMismatchError(MismatchError[bytes]):
     """
 
 
-class RelicSerializationError(RelicToolError):
+class RelicSerializationError(RelicInputFileError):
     """
     An error was raised while serializing an object.
     """
@@ -130,6 +138,7 @@ class RelicArgParserError(Exception):
 
 __all__ = [
     "RelicToolError",
+    "RelicInputFileError",
     "MismatchError",
     "MagicMismatchError",
     "CliError",

--- a/src/relic/core/errors.py
+++ b/src/relic/core/errors.py
@@ -54,9 +54,10 @@ class RelicToolError(Exception):
 
 class RelicInputFileError(RelicToolError):
     """
-    An non critical error was raised during input file parsing. 
+    An non critical error was raised during input file parsing.
 
-    All non critical error raised during input file handling in this library and it's plugins should inherit from this class. Only error message without trace is logged. 
+    All non critical error raised during input file handling in this library and it's plugins should inherit
+    from this class. Only error message without trace is logged.
     """
 
 


### PR DESCRIPTION
Hi I start working on this [Issue](https://github.com/MAK-Relic-Tool/Issue-Tracker/issues/69). 

I added a new exception class `RelicInputFileError` which is used for expected input file errors. This exception is caught in cli.py and logged using cli_logger. This prevents showing traces to the user and stops propagating expected errors.

Will be needed to change `RelicToolError` to `RelicInputFileError` in upstream modules in expected exceptions. 

First I wanted to use the `RelicToolError' directly for this, but `RelicToolError' is used even in places, that are errors and should be handled as such. So I think, that the best solution is to use another wrapper class for exceptions.